### PR TITLE
Remove references to PEP-582

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,13 @@ An example taking the PyTorch [beginner quickstart project](https://pytorch.org/
 
 ## PDM
 
-> PDM, as described, is a modern Python package and dependency manager supporting the latest PEP standards. But it is more than a package manager. It boosts your development workflow in various aspects. The most significant benefit is it installs and manages packages in a similar way to npm that doesn't need to create a virtualenv at all!
->
-> --- [PDM Documentation](https://pdm.fming.dev/latest/#introduction)
+As part of the framework best practices we use [PDM] to manage dependencies of our python software.
 
-As part of the framework best practices we use PDM to manage dependencies of our python software. 
+  [PDM]: https://pdm.fming.dev
 
 ### Installation
 
 PDM should be installed as described in the [Installation instructions](https://pdm.fming.dev/latest/#recommended-installation-method).
-
-### Configuration
-
-PDM provides two ways of storing dependencies, via [virtual environments](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) and via [PEP 583](https://peps.python.org/pep-0582/). The PEP 582 method is suggested as it allows self contained project directories. To enable PEP 582 mode, the following command should be executed in the project directory and will create a file called `.pdm.toml`.
-```bash
-pdm config --local python.use_venv False
-```
-
 ### Initialization
 
 Once PDM is installed and configured, the project should be initialized by running the following command. This will ask a series of questions, where the defaults are usually safe, and produce a file called `pyproject.toml`.
@@ -40,7 +30,11 @@ pdm add torch torchvision
 
 ### Execution
 
-When we have defined our dependencies, we can then run the software. There are two paths to this, if we [globally enable PEP 582](https://pdm.fming.dev/latest/usage/pep582/#enable-pep-582-globally) then we are able to run the code with as a normal python script e.g. `python quickstart_tutorial.py`. However, we can also run in an isolated environment by using `pdm run python quickstart_tutorial.py`.
+When we have defined our dependencies, we can then run the software in an isolated environment by using
+
+```bash
+pdm run python quickstart_tutorial.py
+```
 
 ## Data Version Control (DVC)
 


### PR DESCRIPTION
This PR is to start a conversation about this.

The tutorial is not really the place to discuss finer points of python packaging---it should be more action oriented. The [PDM website](https://pdm.fming.dev/latest/usage/venv/) states that "...virtual environments are considered more mature and have better support in the Python ecosystem as well as IDEs." Since PDM uses virtualenv by default, why work around our tooling? It can be changed back when PDM changes the defaults.

I'm moving the text into the components file on the frameworks website. ([WIP here](https://github.com/nd-crane/nd-crane.github.io/blob/components/Projects/Frameworks/components.qmd))